### PR TITLE
Added psisloo & loo_compare

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "stanity/PSIS"]
+	path = stanity/PSIS
+	url = git@github.com:avehtari/PSIS.git

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ stanity.fit
 stanity.psisloo
     thin wrapper around ``psisloo`` (implemented in https://github.com/avehtari/PSIS/blob/master/py/psis.py)
 stanity.loo_compare
-    compare model fit using PSIS-LOO, analogous to that implemented in the R package loo
+    compare model fit using PSIS-LOO, similar to methods implemented in the R package loo
 
 Installation
 -------------

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,9 @@ Functionality:
 stanity.fit
     thin wrapper around ``pystan.stan`` that caches compiled models
 stanity.psisloo
-    thin wrapper around ``psisloo`` (implemented [here](https://github.com/avehtari/PSIS/blob/master/py/psis.py))
+    thin wrapper around ``psisloo`` (implemented in https://github.com/avehtari/PSIS/blob/master/py/psis.py)
 stanity.loo_compare
-    compare model fit using PSIS-LOO, analogous to that implemented in the R package called [loo](https://github.com/stan-dev/loo)
+    compare model fit using PSIS-LOO, analogous to that implemented in the R package loo
 
 Installation
 -------------

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,10 @@ Functionality:
 
 stanity.fit
     thin wrapper around ``pystan.stan`` that caches compiled models
+stanity.psisloo
+    thin wrapper around ``psisloo`` (implemented [here](https://github.com/avehtari/PSIS/blob/master/py/psis.py))
+stanity.loo_compare
+    compare model fit using PSIS-LOO, analogous to that implemented in the R package called [loo](https://github.com/stan-dev/loo)
 
 Installation
 -------------

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,4 @@ setup(
         "pandas",
         "seaborn",
     ],
-    dependency_links=[
-        "https://raw.githubusercontent.com/avehtari/PSIS/master/py/psis.py"
-    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-version = "0.2.1"
+version = "0.2.2"
 
 setup(
     name="stanity",

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,7 @@ setup(
         "future>=0.14.3",
         "pandas",
         "seaborn",
+        "matplotlib",
+	"numpy",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,6 @@ setup(
         "pandas",
         "seaborn",
         "matplotlib",
-	"numpy",
+    "numpy",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,8 @@ setup(
         "future>=0.14.3",
         "pandas",
         "seaborn",
-    ]
+    ],
+    dependency_links=[
+        "https://raw.githubusercontent.com/avehtari/PSIS/master/py/psis.py"
+    ],
 )

--- a/stanity/__init__.py
+++ b/stanity/__init__.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 
 from .fit import fit
-from .psisloo import Psisloo, psisloo, loo_compare
+from .psisloo import Psisloo, psisloo
 
 __all__ = [
     "fit",
     "psisloo",
     "Psisloo",
-    "loo_compare",
 ]

--- a/stanity/__init__.py
+++ b/stanity/__init__.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import
 
 from .fit import fit
 from .psisloo import Psisloo, psisloo, loo_compare
+from .utilities import print_dict
 
 __all__ = [
     "fit",
     "psisloo",
     "Psisloo",
     "loo_compare",
+    "print_dict",
 ]

--- a/stanity/__init__.py
+++ b/stanity/__init__.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 
 from .fit import fit
-from .psisloo import Psisloo, psisloo
+from .psisloo import Psisloo, psisloo, loo_compare
 
 __all__ = [
     "fit",
     "psisloo",
     "Psisloo",
+    "loo_compare",
 ]

--- a/stanity/__init__.py
+++ b/stanity/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from .fit import fit
+from .psisloo import Psisloo, psisloo
 
 __all__ = [
     "fit",

--- a/stanity/__init__.py
+++ b/stanity/__init__.py
@@ -4,4 +4,6 @@ from .fit import fit
 
 __all__ = [
     "fit",
+    "psisloo",
+    "Psisloo",
 ]

--- a/stanity/psis.py
+++ b/stanity/psis.py
@@ -1,0 +1,1 @@
+PSIS/py/psis.py

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -21,11 +21,11 @@ class Psisloo(object):
         self.summary['greater than 1'] = self.summary.pareto_k > 1
 
     def print_summary(self):
-        self.summary.apply(numpy.mean)[2:]
+        return self.summary.apply(numpy.mean)[2:]
 
     def plot(self):
         seaborn.pointplot(y = self.pointwise.pareto_k, x = self.pointwise.index, join = False)
-        pyplot.axhline(0.5)
+        #pyplot.axhline(0.5)
 
 def psisloo(log_lik, *args, **kwargs):
     """

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -8,55 +8,55 @@ import matplotlib as pyplot
 
 class Psisloo(object):
     def __init__(self, log_lik):
-    	self.log_lik = log_lik
-    	self.result = psis.psisloo(log_lik=log_lik)
-    	self.looic = print(-2*self.result[0])
-    	self.pointwise = pandas.DataFrame({'pointwise_elpd' : self.result[1], 'pareto_k': self.result[2]})
-    	self._summarize_pointwise()
+        self.log_lik = log_lik
+        self.result = psis.psisloo(log_lik=log_lik)
+        self.looic = print(-2*self.result[0])
+        self.pointwise = pandas.DataFrame({'pointwise_elpd' : self.result[1], 'pareto_k': self.result[2]})
+        self._summarize_pointwise()
 
-	def _summarize_pointwise(self):
-		self.summary = self.pointwise.copy()
-		self.summary['greater than 0.5'] = self.summary.pareto_k > 0.5
-		self.summary['greater than 1'] = self.summary.pareto_k > 1
+    def _summarize_pointwise(self):
+        self.summary = self.pointwise.copy()
+        self.summary['greater than 0.5'] = self.summary.pareto_k > 0.5
+        self.summary['greater than 1'] = self.summary.pareto_k > 1
 
     def print_summary(self):
-		self.summary.apply(numpy.mean)[2:]
+        self.summary.apply(numpy.mean)[2:]
 
-	def plot(self):
-		seaborn.pointplot(y = self.pointwise.pareto_k, x = self.pointwise.index, join = False)
-		pyplot.axhline(0.5)
+    def plot(self):
+        seaborn.pointplot(y = self.pointwise.pareto_k, x = self.pointwise.index, join = False)
+        pyplot.axhline(0.5)
 
 def psisloo(log_lik, *args, **kwargs):
-	"""
-	Summarize the model fit using Pareto-smoothed importance sampling (PSIS) 
-	and approximate Leave-One-Out cross-validation (LOO).
-	
-	Takes as input a matrix of log_likelihood evaluations, per observation * iter:
-		e.x.
-		loosummary = loo(stan_fit.extract()['log_lik'])
+    """
+    Summarize the model fit using Pareto-smoothed importance sampling (PSIS) 
+    and approximate Leave-One-Out cross-validation (LOO).
+    
+    Takes as input a matrix of log_likelihood evaluations, per observation * iter:
+        e.x.
+        loosummary = loo(stan_fit.extract()['log_lik'])
 
-	Returns a Psisloo object 
+    Returns a Psisloo object 
 
-	References
-	----------
-	
-	Aki Vehtari, Andrew Gelman and Jonah Gabry (2015). Efficient implementation
-	of leave-one-out cross-validation and WAIC for evaluating fitted Bayesian
-	models. arXiv preprint arXiv:1507.04544.
+    References
+    ----------
+    
+    Aki Vehtari, Andrew Gelman and Jonah Gabry (2015). Efficient implementation
+    of leave-one-out cross-validation and WAIC for evaluating fitted Bayesian
+    models. arXiv preprint arXiv:1507.04544.
 
-	Aki Vehtari and Andrew Gelman (2015). Pareto smoothed importance sampling.
-	arXiv preprint arXiv:1507.02646.
-	"""
-	return Psisloo(log_lik)
+    Aki Vehtari and Andrew Gelman (2015). Pareto smoothed importance sampling.
+    arXiv preprint arXiv:1507.02646.
+    """
+    return Psisloo(log_lik)
 
 
 def loo_compare(psisloo1, psisloo2):
     """
     Compares two models using pointwise approximate leave-one-out cross validation.
-	
-	For the method to be valid, the two models should have been fit on the same input data. 
+    
+    For the method to be valid, the two models should have been fit on the same input data. 
 
-	Parameters
+    Parameters
     -------------------
     psisloo1 : Psisloo object for model1
     psisloo2 : Psisloo object for model2
@@ -64,14 +64,14 @@ def loo_compare(psisloo1, psisloo2):
     Returns
     -------------------
     Dict summarizing difference between two models, where a positive value indicates
-    	that model2 is a better fit than model1.
+        that model2 is a better fit than model1.
 
     """
     ## TODO: confirm that dimensions for psisloo1 & psisloo2 are the same
     loores = psisloo1.pointwise.join(psisloo2.pointwise, lsuffix = '_m1', rsuffix = '_m2')
     loores['pw_diff'] = loores.pointwise_elpd_m2 - loores.pointwise_elpd_m1
-	sum_elpd_diff = loores.apply(numpy.sum).pw_diff
-	sd_elpd_diff = loores.apply(numpy.std).pw_diff
-	elpd_diff = {'diff' : sum_elpd_diff, 'se_diff' : math.sqrt(len(loores.pw_diff)) * sd_elpd_diff}
-	return elpd_diff
+    sum_elpd_diff = loores.apply(numpy.sum).pw_diff
+    sd_elpd_diff = loores.apply(numpy.std).pw_diff
+    elpd_diff = {'diff' : sum_elpd_diff, 'se_diff' : math.sqrt(len(loores.pw_diff)) * sd_elpd_diff}
+    return elpd_diff
 

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -10,13 +10,14 @@ class Psisloo(object):
     def __init__(self, log_lik):
     	self.log_lik = log_lik
     	self.result = psis.psisloo(log_lik=log_lik)
-    	self.looic = print(-2*self.result[0])
+    	self.looic = -2*self.result[0]
+        self.elpd = self.result[0]
     	self.pointwise = pandas.DataFrame({'pointwise_elpd' : self.result[1], 'pareto_k': self.result[2]})
     	self._summarize_pointwise()
 
 	def _summarize_pointwise(self):
 		self.summary = self.pointwise.copy()
-    	self.summary['greater than 0.5'] = self.summary.pareto_k > 0.5
+		self.summary['greater than 0.5'] = self.summary.pareto_k > 0.5
 		self.summary['greater than 1'] = self.summary.pareto_k > 1
 
     def print_summary(self):

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -10,7 +10,8 @@ class Psisloo(object):
     def __init__(self, log_lik):
         self.log_lik = log_lik
         self.result = psis.psisloo(log_lik=log_lik)
-        self.looic = print(-2*self.result[0])
+        self.looic = -2*self.result[0]
+        self.looic = self.result[0]
         self.pointwise = pandas.DataFrame({'pointwise_elpd' : self.result[1], 'pareto_k': self.result[2]})
         self._summarize_pointwise()
 

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -1,5 +1,5 @@
 
-from PSIS.py import psis
+import psis
 import pandas
 import math
 import numpy

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -79,14 +79,14 @@ def psisloo(log_likelihood):
     Summarize the model fit using Pareto-smoothed importance sampling (PSIS) 
     and approximate Leave-One-Out cross-validation (LOO).
     
-    Takes as input an ndarray of posterior log likelihood terms [ p(y_i | \theta^s) ]
+    Takes as input an ndarray of posterior log likelihood terms [ p( y_i | theta^s ) ]
         per observation unit.
 
         e.x. if using pystan:
 
-        loosummary = loo(stan_fit.extract()['log_lik'])
+        loosummary = stanity.psisloo(stan_fit.extract()['log_lik'])
 
-    Returns a Psisloo object
+    Returns a Psisloo object. Useful methods such as print_summary() & plot().
 
     References
     ----------

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -11,7 +11,7 @@ class Psisloo(object):
         self.log_lik = log_lik
         self.result = psis.psisloo(log_lik=log_lik)
         self.looic = -2*self.result[0]
-        self.looic = self.result[0]
+        self.elpd = self.result[0]
         self.pointwise = pandas.DataFrame({'pointwise_elpd' : self.result[1], 'pareto_k': self.result[2]})
         self._summarize_pointwise()
 

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -116,7 +116,7 @@ def loo_compare(psisloo1, psisloo2):
     -------------------
     Dict with two values:
 
-        diff: difference in elpd (estimated log predictive density) 
+        diff: difference in elpd (estimated log predicted density) 
                 between two models, where a positive value indicates
                 that model2 is a better fit than model1.
 

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -1,5 +1,5 @@
 
-import psis
+from PSIS.py import psis
 import pandas
 import math
 import numpy

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -10,14 +10,13 @@ class Psisloo(object):
     def __init__(self, log_lik):
     	self.log_lik = log_lik
     	self.result = psis.psisloo(log_lik=log_lik)
-    	self.looic = -2*self.result[0]
-        self.elpd = self.result[0]
+    	self.looic = print(-2*self.result[0])
     	self.pointwise = pandas.DataFrame({'pointwise_elpd' : self.result[1], 'pareto_k': self.result[2]})
     	self._summarize_pointwise()
 
 	def _summarize_pointwise(self):
 		self.summary = self.pointwise.copy()
-		self.summary['greater than 0.5'] = self.summary.pareto_k > 0.5
+    	self.summary['greater than 0.5'] = self.summary.pareto_k > 0.5
 		self.summary['greater than 1'] = self.summary.pareto_k > 1
 
     def print_summary(self):

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -1,0 +1,77 @@
+
+import psis
+import pandas
+import math
+import numpy
+import seaborn
+import matplotlib as pyplot
+
+class Psisloo(object):
+    def __init__(self, log_lik):
+    	self.log_lik = log_lik
+    	self.result = psis.psisloo(log_lik=log_lik)
+    	self.looic = print(-2*self.result[0])
+    	self.pointwise = pandas.DataFrame({'pointwise_elpd' : self.result[1], 'pareto_k': self.result[2]})
+    	self._summarize_pointwise()
+
+	def _summarize_pointwise(self):
+		self.summary = self.pointwise.copy()
+    	self.summary['greater than 0.5'] = self.summary.pareto_k > 0.5
+		self.summary['greater than 1'] = self.summary.pareto_k > 1
+
+    def print_summary(self):
+		self.summary.apply(numpy.mean)[2:]
+
+	def plot(self):
+		seaborn.pointplot(y = self.pointwise.pareto_k, x = self.pointwise.index, join = False)
+		pyplot.axhline(0.5)
+
+def psisloo(log_lik, *args, **kwargs):
+	"""
+	Summarize the model fit using Pareto-smoothed importance sampling (PSIS) 
+	and approximate Leave-One-Out cross-validation (LOO).
+	
+	Takes as input a matrix of log_likelihood evaluations, per observation * iter:
+		e.x.
+		loosummary = loo(stan_fit.extract()['log_lik'])
+
+	Returns a Psisloo object 
+
+	References
+	----------
+	
+	Aki Vehtari, Andrew Gelman and Jonah Gabry (2015). Efficient implementation
+	of leave-one-out cross-validation and WAIC for evaluating fitted Bayesian
+	models. arXiv preprint arXiv:1507.04544.
+
+	Aki Vehtari and Andrew Gelman (2015). Pareto smoothed importance sampling.
+	arXiv preprint arXiv:1507.02646.
+	"""
+	return Psisloo(log_lik)
+
+
+def loo_compare(psisloo1, psisloo2):
+    """
+    Compares two models using pointwise approximate leave-one-out cross validation.
+	
+	For the method to be valid, the two models should have been fit on the same input data. 
+
+	Parameters
+    -------------------
+    psisloo1 : Psisloo object for model1
+    psisloo2 : Psisloo object for model2
+
+    Returns
+    -------------------
+    Dict summarizing difference between two models, where a positive value indicates
+    	that model2 is a better fit than model1.
+
+    """
+    ## TODO: confirm that dimensions for psisloo1 & psisloo2 are the same
+    loores = psisloo1.pointwise.join(psisloo2.pointwise, lsuffix = '_m1', rsuffix = '_m2')
+    loores['pw_diff'] = loores.pointwise_elpd_m2 - loores.pointwise_elpd_m1
+	sum_elpd_diff = loores.apply(numpy.sum).pw_diff
+	sd_elpd_diff = loores.apply(numpy.std).pw_diff
+	elpd_diff = {'diff' : sum_elpd_diff, 'se_diff' : math.sqrt(len(loores.pw_diff)) * sd_elpd_diff}
+	return elpd_diff
+

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -6,9 +6,9 @@ import numpy
 import seaborn
 
 class Psisloo(object):
-    def __init__(self, log_lik):
-        self.log_lik = log_lik
-        self.result = psis.psisloo(log_lik=log_lik)
+    def __init__(self, log_likelihood):
+        self.log_lik = log_likelihood
+        self.result = psis.psisloo(log_lik=self.log_lik)
         self.looic = -2*self.result[0]
         self.elpd = self.result[0]
         self.pointwise = pandas.DataFrame(
@@ -31,7 +31,7 @@ class Psisloo(object):
             join = False)
         #pyplot.axhline(0.5)
 
-def psisloo(log_lik):
+def psisloo(log_likelihood):
     """
     Summarize the model fit using Pareto-smoothed importance sampling (PSIS) 
     and approximate Leave-One-Out cross-validation (LOO).
@@ -52,7 +52,7 @@ def psisloo(log_lik):
     Aki Vehtari and Andrew Gelman (2015). Pareto smoothed importance sampling.
     arXiv preprint arXiv:1507.02646.
     """
-    return Psisloo(log_lik)
+    return Psisloo(log_likelihood)
 
 
 def loo_compare(psisloo1, psisloo2):

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -10,7 +10,7 @@ class Psisloo(object):
 
     This class stores results from approximate leave-one-out cross validation using
     Pareto-smoothed importance sampling (PSIS-LOO). Object contains pointwise 
-    expected log predicted density (elpd) and pointwise pareto-k importance 
+    expected log predictive density (elpd) and pointwise pareto-k importance 
     metrics, as well as summary metrics such as WAIC. 
 
     Taken in concert, these metrics can be used for model comparison and model checking.
@@ -116,7 +116,7 @@ def loo_compare(psisloo1, psisloo2):
     -------------------
     Dict with two values:
 
-        diff: difference in elpd (estimated log predicted density) 
+        diff: difference in elpd (estimated log predictive density) 
                 between two models, where a positive value indicates
                 that model2 is a better fit than model1.
 

--- a/stanity/psisloo.py
+++ b/stanity/psisloo.py
@@ -16,7 +16,7 @@ class Psisloo(object):
 
 	def _summarize_pointwise(self):
 		self.summary = self.pointwise.copy()
-    	self.summary['greater than 0.5'] = self.summary.pareto_k > 0.5
+		self.summary['greater than 0.5'] = self.summary.pareto_k > 0.5
 		self.summary['greater than 1'] = self.summary.pareto_k > 1
 
     def print_summary(self):

--- a/stanity/utilities.py
+++ b/stanity/utilities.py
@@ -1,0 +1,9 @@
+
+import numpy
+
+def print_dict(d):
+    for key in [key for key in d if not isinstance(d[key], numpy.ndarray)]:
+        print("%s: %s" % (key, d[key]))
+    for key in [key for key in d if isinstance(d[key], numpy.ndarray)]:
+        print("%s: %s mean=%s std=%s" % (key,  d[key].shape, d[key].mean(), d[key].std()))
+

--- a/test/test_psisloo.py
+++ b/test/test_psisloo.py
@@ -1,0 +1,114 @@
+from nose.tools import eq_
+import numpy
+
+import stanity
+
+def test_psisloo():
+    # Test psisloo calculation using a toy linear regression.
+
+    true_a = 52.3
+    true_b = -30
+    num_points = 100
+
+    model_code = """
+        data {
+            int<lower=0> num_points;
+            vector[num_points] x;
+            vector[num_points] y;
+        }
+        parameters {
+            real a;
+            real b;
+        }
+        model {
+            y ~ normal(a * x + b, 2);
+            a ~ normal(0, 100);
+            b ~ normal(0, 100);
+        }
+        generated quantities {
+            real y_rep[num_points];
+            real log_lik[num_points];
+            
+            for (i in 1:num_points) {
+                y_rep[i] <- normal_rng(a * x[i] + b, 2);
+                log_lik[i] <- normal_log(y[i], a * x[i] + b, 2);
+            }
+        }
+    """
+    noise = numpy.random.normal(scale=0.1, size=num_points)
+    x = numpy.random.uniform(-1000, 1000, size=num_points)
+    data = {
+        'num_points': num_points,
+        'x': x,
+        'y': true_a * x + true_b + noise,
+    }
+    fit = stanity.fit(model_code, data=data, iter=10000, chains=2)
+    extracted = fit.extract()
+    
+    loo = stanity.psisloo(extracted['log_lik'])
+    loo_summ = loo.summary.apply(numpy.mean)[2:]
+    
+    numpy.testing.assert_almost_equal(loo_summ['greater than 0.5'], 0, decimal=3)
+    numpy.testing.assert_almost_equal(loo_summ['greater than 1'], 0, decimal=3)
+
+def test_loo_compare():
+    # Test loo_compare using a toy linear regression.
+
+    true_a = 52.3
+    true_b = -30
+    num_points = 100
+
+    model_code = """
+        data {
+            int<lower=0> num_points;
+            vector[num_points] x;
+            vector[num_points] y;
+        }
+        parameters {
+            real a;
+            real b;
+        }
+        model {
+            y ~ normal(a * x + b, 2);
+            a ~ normal(0, 100);
+            b ~ normal(0, 100);
+        }
+        generated quantities {
+            real y_rep[num_points];
+            real log_lik[num_points];
+            
+            for (i in 1:num_points) {
+                y_rep[i] <- normal_rng(a * x[i] + b, 2);
+                log_lik[i] <- normal_log(y[i], a * x[i] + b, 2);
+            }
+        }
+    """
+    noise = numpy.random.normal(scale=0.1, size=num_points)
+    x = numpy.random.uniform(-10, 10, size=num_points)
+    
+    ## first fit (correct fit)
+    data1 = {
+        'num_points': num_points,
+        'x': x,
+        'y': true_a * x + true_b + noise,
+    }
+    fit1 = stanity.fit(model_code, data=data1, iter=10000, chains=2)
+    ext1 = fit1.extract()
+    loo1 = stanity.psisloo(ext1['log_lik'])
+    
+    ## second fit (should be worse)
+    data2 = {
+        'num_points': num_points,
+        'x': numpy.exp(x),
+        'y': true_a * x + true_b + noise,
+    }
+    fit2 = stanity.fit(model_code, data=data2, iter=10000, chains=2)
+    ext2 = fit2.extract()
+    loo2 = stanity.psisloo(ext2['log_lik'])
+
+    ## compare loo1 & loo2
+    comparison = stanity.loo_compare(loo1, loo2)
+    
+    assert comparison['diff'] < 0
+    assert comparison['diff'] < -1000
+


### PR DESCRIPTION
Added psisloo & loo_compare functions, as thin wrappers around Aki Vehtari's [PSIS repo ](https://github.com/avehtari/PSIS/blob/master/py/psis.py). References issue #5. 

Currently imports this code using a git submodule. Would be better to modify Aki's repo to enable direct import from git via `pip`, but git-submodule should be OK for now. 

For now, since we are using git submodules, best practice is as follows : 
- Use `git clone --recursive` when checking out this repo
- Or, to run `git submodule update --init --recursive` after checkout / update
